### PR TITLE
WIP: add image pasting to compose window

### DIFF
--- a/src/compose/compose.html
+++ b/src/compose/compose.html
@@ -47,6 +47,7 @@
           @drop.native="drop"
           @dragenter.native="dragenter"
           @dragleave.native="dragleave"
+          @paste.native="paste"
           @select="option => selected = option"
         >
         </b-autocomplete>

--- a/src/compose/compose.js
+++ b/src/compose/compose.js
@@ -29,6 +29,17 @@ const example = {
     };
   },
   methods: {
+    paste: function(event) {
+      let clipboard_items = event.clipboardData.items;
+
+      for (var i = 0; i < clipboard_items.length; i++) {
+        let item = clipboard_items[i];
+
+        if(item.kind == "file" && item.type.match("^image/")) {
+          this.addAttachment(item.getAsFile(), "Pasted Image");
+        }
+      }
+    },
     dragenter: function(event) {
       console.log('drag enter');
       this.isDragging = true;
@@ -42,18 +53,7 @@ const example = {
       this.dragleave();
 
       for (let file of event.dataTransfer.files) {
-        console.log(file);
-        let path = file.path;
-        let file_copy = {
-          path: file.path,
-          name: file.name,
-          size: file.size,
-          obj: file,
-        };
-        this.attachments.push({
-          file: file_copy,
-          url: URL.createObjectURL(file),
-        });
+        this.addAttachment(file);
       }
 
       return false;
@@ -80,6 +80,23 @@ const example = {
         this.getAsyncData();
       }
       return true;
+    },
+    addAttachment: function(file, file_name = null) {
+      if (file_name) {
+        file_name = [file_name, file.name.split('.').pop()].join('.');
+      }
+
+      let file_copy = {
+        path: file.path,
+        name: file_name || file.name,
+        size: file.size,
+        obj: file,
+      };
+
+      this.attachments.push({
+        file: file_copy,
+        url: URL.createObjectURL(file),
+      });
     },
     submitForm: function() {
       todoBody.disabled = true;

--- a/src/wip.js
+++ b/src/wip.js
@@ -94,6 +94,8 @@ function uploadFile(presigned_url, file) {
       form.append(field, presigned_url.fields[field]);
     }
 
+    // FIXME: Pasted images have no path, and file.file.obj is emptied
+    logger.log(file.file.obj);
     form.append('file', fs.createReadStream(file.file.path));
 
     form.submit(presigned_url.url, function(error, response) {


### PR DESCRIPTION
Adds the ability to paste image from clipboard into the compose window.

It doesn't work yet, because pasted files don't have a `.path` we can use for `fs.createReadStream()` when uploading the file.

Need to figure out how to pass Files from the renderer process to the main process. Writing to a temporary cache might work. See https://github.com/electron/electron/issues/13038#issuecomment-419396445