### PR TITLE
Hashtag at the end of TODO with TAB for autocompletion

### DIFF
--- a/src/compose/vue/App.vue
+++ b/src/compose/vue/App.vue
@@ -240,8 +240,6 @@ export default {
       if (this.mode === Mode.Hashtag) {
         const isLastHashtag = /.*#\w+\s*$/i.test(this.name);
         if (!isLastHashtag) return;
-        if (!this.hashtags.find((e) => e.hashtag === this.selectedHashtag))
-          return;
       }
 
       this.inputField.disabled = true;


### PR DESCRIPTION
### Problem
Allow user to create TODO or append hashtag to the current hashtag via single `Enter` button

### The best solution
On Enter pressed check what is selected in the dropdown:
- If any hashtag is selected append it to the TODO
- If none selected call to create/complete TODO API

Unfortunately, [buefy](https://buefy.org/documentation/autocomplete/) doesn't have any API to get the selected field in runtime. It has `@select` event, which is triggered after the user press `Enter`. 
Buefy event order:
1. Trigger `@select` on Enter pressed with the hashtag
2. Trigger `@select` after dropdown closed with null
3. Trigger `@keydown.enter` and submit the form

### This workaround
On Enter hit in hashtag mode hashtag will be autocompleted and sent to the backend
On Tab hit in hashtag mode hashtag will be appended to the end of TODO
