### PR TITLE
Fix openExternal in renderer process

### DIFF
--- a/src/ipc/channels.js
+++ b/src/ipc/channels.js
@@ -4,5 +4,6 @@ exports.Channels = {
   FetchHashtags: 'app/fetch/hashtags',
   Log: 'app/log',
   StoreGet: 'app/store/get',
-  StoreGetMultiple: 'app/store/get_multi',
+  StoreGetMultiple: 'app/store/getMulti',
+  OpenExternalUrl: 'app/shell/openExternalUrl',
 };

--- a/src/ipc/main.js
+++ b/src/ipc/main.js
@@ -1,4 +1,4 @@
-const { ipcMain, BrowserWindow } = require('electron');
+const { ipcMain, BrowserWindow, shell } = require('electron');
 const logger = require('../logger');
 const store = require('../store');
 
@@ -25,6 +25,10 @@ ipcMain.handle(Channels.StoreGetMultiple, async (event, ...args) => {
     result[arg] = store.get(arg);
   }
   return Promise.resolve(result);
+});
+
+ipcMain.on(Channels.OpenExternalUrl, async (event, url) => {
+  shell.openExternal(url);
 });
 
 ipcMain.on(Channels.Log, async (event, level, ...args) => {

--- a/src/preload.js
+++ b/src/preload.js
@@ -1,4 +1,4 @@
-const { ipcRenderer, shell, contextBridge } = require('electron');
+const { ipcRenderer, contextBridge } = require('electron');
 const utils = require('./ipc/renderer');
 const { Channels } = require('./ipc/channels');
 
@@ -10,7 +10,9 @@ function logGeneric(level, ...args) {
 
 const context = {
   electron: {
-    shell,
+    shell: {
+      openExternal: (url) => ipcRenderer.send(Channels.OpenExternalUrl, url),
+    },
     ipcRenderer: {
       send: ipcRenderer.send,
       invoke: ipcRenderer.invoke,


### PR DESCRIPTION
- Replace direct `shell.openExternal(url)` call with IPC